### PR TITLE
ポイント付与後に会員編集時に付与ポイント欄を空白でも対応するように修正

### DIFF
--- a/Event/WorkPlace/FrontShoppingComplete.php
+++ b/Event/WorkPlace/FrontShoppingComplete.php
@@ -100,6 +100,12 @@ class FrontShoppingComplete extends AbstractWorkPlace
         );
 
         if ($calculateCurrentPoint < 0) {
+
+            $this->app['monolog.point']->addInfo('save current point', array(
+                    'current point' => $calculateCurrentPoint,
+                )
+            );
+
             // TODO: ポイントがマイナス！
             // ポイントがマイナスの時はメール送信
             $this->app['eccube.plugin.point.mail.helper']->sendPointNotifyMail($Order, $calculateCurrentPoint, $usePoint);

--- a/Helper/PointHistoryHelper/PointHistoryHelper.php
+++ b/Helper/PointHistoryHelper/PointHistoryHelper.php
@@ -204,7 +204,7 @@ class PointHistoryHelper
         $this->entities['Point']->setPlgPointId(null);
         $this->entities['Point']->setCustomer($this->entities['Customer']);
         $this->entities['Point']->setPointInfo($this->entities['PointInfo']);
-        $this->entities['Point']->setPlgDynamicPoint($point);
+        $this->entities['Point']->setPlgDynamicPoint((integer)$point);
         $this->entities['Point']->setPlgPointActionName($this->historyActionType.$this->currentActionName);
         $this->entities['Point']->setPlgPointType($this->historyType);
         try {

--- a/Repository/PointCustomerRepository.php
+++ b/Repository/PointCustomerRepository.php
@@ -35,7 +35,7 @@ class PointCustomerRepository extends EntityRepository
         }
 
         $PointCustomer = new PointCustomer();
-        $PointCustomer->setPlgPointCurrent($point);
+        $PointCustomer->setPlgPointCurrent((integer)$point);
         $PointCustomer->setCustomer($customer);
 
         $em = $this->getEntityManager();

--- a/Repository/PointRepository.php
+++ b/Repository/PointRepository.php
@@ -42,14 +42,16 @@ class PointRepository extends EntityRepository
                     )
                 )
                 ->orWhere(
-                    $qb->expr()->eq('p.plg_point_type', PointHistoryHelper::STATE_USE)
+                    $qb->expr()->andX(
+                        $qb->expr()->eq('p.plg_point_type', PointHistoryHelper::STATE_USE),
+                        $qb->expr()->eq('p.customer_id', $customer_id)
+                    )
                 );
             if (!empty($orderIds)) {
                 $qb->orWhere($qb->expr()->in('p.order_id', $orderIds));
             }
             // 合計ポイント
             $point = $qb->getQuery()->getSingleScalarResult();
-
             return (int)$point;
         } catch (NoResultException $e) {
             return 0;

--- a/Resource/template/admin/Mail/point_notify.twig
+++ b/Resource/template/admin/Mail/point_notify.twig
@@ -9,7 +9,7 @@
 * file that was distributed with this source code.
 */
 #}
-会員ID：{{ Order.customer_id }}
+会員ID：{{ Order.Customer.id }}
 {{ Order.name01 }} {{ Order.name02 }} 様の保有ポイントがマイナスになっています。
 
 注文番号：{{ Order.id }}


### PR DESCRIPTION
#41 ポイント付与後に会員編集時に付与ポイント欄を空白でも対応するように修正

下記の不具合も合わせて修正
- 新規会員登録後、最初の購入時にマイナスポイントが付与される不具合修正
- ポイントマイナス時のメール通知不具合修正
