### PR TITLE
会員編集時に付与ポイント欄を空白でも対応するように修正

### DIFF
--- a/Helper/PointHistoryHelper/PointHistoryHelper.php
+++ b/Helper/PointHistoryHelper/PointHistoryHelper.php
@@ -230,7 +230,7 @@ class PointHistoryHelper
         $this->entities['SnapShot']->setPlgPointSnapshotId(null);
         $this->entities['SnapShot']->setCustomer($this->entities['Customer']);
         $this->entities['SnapShot']->setPlgPointAdd($point['add']);
-        $this->entities['SnapShot']->setPlgPointCurrent($point['current']);
+        $this->entities['SnapShot']->setPlgPointCurrent((integer)$point['current']);
         $this->entities['SnapShot']->setPlgPointUse($point['use']);
         $this->entities['SnapShot']->setPlgPointSnapActionName($this->currentActionName);
         try {


### PR DESCRIPTION
#41 #52 の追加修正です

snapshotの登録タイミングで同様のエラーが発生したため
