### PR TITLE
仮利用ポイントの登録処理を削除

### DIFF
--- a/Event/WorkPlace/FrontShoppingComplete.php
+++ b/Event/WorkPlace/FrontShoppingComplete.php
@@ -43,12 +43,8 @@ class FrontShoppingComplete extends AbstractWorkPlace
 
         $Order = $event->getArgument('Order');
 
-        // 仮利用ポイントを相殺して登録
-        $usePoint = $this->app['eccube.plugin.point.repository.point']->getLatestPreUsePoint($Order);
-        $this->app['eccube.plugin.point.history.service']->addEntity($Order);
-        $this->app['eccube.plugin.point.history.service']->addEntity($Order->getCustomer());
-        $this->app['eccube.plugin.point.history.service']->savePreUsePoint($usePoint * -1);
         // 利用ポイントを登録
+        $usePoint = $this->app['eccube.plugin.point.repository.point']->getLatestPreUsePoint($Order);
         $this->app['eccube.plugin.point.history.service']->refreshEntity();
         $this->app['eccube.plugin.point.history.service']->addEntity($Order);
         $this->app['eccube.plugin.point.history.service']->addEntity($Order->getCustomer());


### PR DESCRIPTION
#51, #74 の通り, 仮利用ポイントは積算を行わないため、購入完了時にレコードを追加する必要はない
