### PR TITLE
保有ポイントの集計処理の修正

### DIFF
--- a/Repository/PointRepository.php
+++ b/Repository/PointRepository.php
@@ -79,7 +79,8 @@ class PointRepository extends EntityRepository
             $qb = $this->createQueryBuilder('p');
             $qb->select('SUM(p.plg_dynamic_point) as point_sum')
                 ->where($qb->expr()->in('p.order_id', $orderIds))
-                ->andWhere($qb->expr()->neq('p.plg_point_type', PointHistoryHelper::STATE_USE));
+                ->andWhere($qb->expr()->neq('p.plg_point_type', PointHistoryHelper::STATE_USE))
+                ->andWhere($qb->expr()->neq('p.plg_point_type', PointHistoryHelper::STATE_PRE_USE));
 
             $point = $qb->getQuery()->getSingleScalarResult();
 

--- a/Repository/PointRepository.php
+++ b/Repository/PointRepository.php
@@ -48,7 +48,12 @@ class PointRepository extends EntityRepository
                     )
                 );
             if (!empty($orderIds)) {
-                $qb->orWhere($qb->expr()->in('p.order_id', $orderIds));
+                $qb->orWhere(
+                    $qb->expr()->andX(
+                        $qb->expr()->neq('p.plg_point_type', PointHistoryHelper::STATE_PRE_USE),
+                        $qb->expr()->in('p.order_id', $orderIds)
+                    )
+                );
             }
             // 合計ポイント
             $point = $qb->getQuery()->getSingleScalarResult();


### PR DESCRIPTION
#108 の修正
#84 関連で、仮利用ポイントの打ち消し処理を削除したが、保有ポイント集計で仮利用ポイントを除外する必要があった。

影響箇所は以下のとおり。
- PointRepository::calcCurrentPoint 
- PointRepository::calcProvisionalAddPoint

仮利用ポイントを集計対象から除外するように修正しました。
