### PR TITLE
メールのエンコーディングがUTF-8以外の場合、一旦UTF-8に変換してからポイント情報を差し込むように修正

### DIFF
--- a/Event/WorkPlace/ServiceMail.php
+++ b/Event/WorkPlace/ServiceMail.php
@@ -14,6 +14,8 @@ namespace Plugin\Point\Event\WorkPlace;
 use Eccube\Event\EventArgs;
 use Symfony\Component\Validator\Constraints as Assert;
 
+const ENCODING = 'UTF-8';
+
 /**
  * フックポイント汎用処理具象クラス
  *  - 拡張元 : 受注メール
@@ -77,6 +79,14 @@ class ServiceMail extends AbstractWorkPlace
         // メールボディ取得
         $body = $message->getBody();
 
+        // エンコード方式取得
+        $charset = $message->getCharset();
+
+        if ($charset != ENCODING) {
+            // 一旦UTF-8に
+            $body = mb_convert_encoding($body, ENCODING, $charset);
+        }
+
         // 情報置換用のキーを取得
         $search = array();
         preg_match_all('/合　計.*\\n/u', $body, $search);
@@ -94,6 +104,11 @@ class ServiceMail extends AbstractWorkPlace
         $replace = $search[0][0].$snippet;
         $body = preg_replace('/'.$search[0][0].'/u', $replace, $body);
 
+        if ($charset != ENCODING) {
+            // エンコーディングを元に戻す
+            $body = mb_convert_encoding($body, $charset, ENCODING);
+        }
+        
         // メッセージにメールボディをセット
         $message->setBody($body);
 


### PR DESCRIPTION
メール設定が「charset_iso_2022_jp: true」のとき、
購入確認メールにポイント情報が大量に挿入される問題を修正しました。
※はじめてのPRです。何かおかしなことがあればご指摘くださいm(__)m