### PR TITLE
[modify] 購入確認画面でポイント使用をクリックしたときに配送日時が保存されるように修正。

### DIFF
--- a/Controller/FrontPointController.php
+++ b/Controller/FrontPointController.php
@@ -37,19 +37,7 @@ class FrontPointController
             return $app->redirect($app->url('shopping_error'));
         }
 
-        if ('POST' !== $request->getMethod()) {
-            return $app->redirect($app->url('shopping'));
-        }
-
         $builder = $app['eccube.service.shopping']->getShippingFormBuilder($Order);
-
-        $event = new EventArgs(
-            array(
-                'builder' => $builder,
-                'Order' => $Order,
-            ),
-            $request
-        );
 
         $form = $builder->getForm();
 
@@ -59,8 +47,10 @@ class FrontPointController
             $data = $form->getData();
             $message = $data['message'];
             $Order->setMessage($message);
-            // 受注情報を更新
-            $app['orm.em']->flush();
+            foreach ($Order->getShippings() as $Shipping) {
+                // 配送情報を更新
+                $app['orm.em']->flush($Shipping);
+            }
 
             // 使用ポイント入力ページへ遷移
             return $app->redirect($app->url('point_use', array('id' => $id)));

--- a/Event/WorkPlace/FrontShopping.php
+++ b/Event/WorkPlace/FrontShopping.php
@@ -83,6 +83,7 @@ class FrontShopping extends AbstractWorkPlace
         $snippet = $this->app->renderView(
             'Point/Resource/template/default/Event/ShoppingConfirm/use_point_button.twig',
             array(
+                'Order' => $Order,
                 'point' => $point,
             )
         );

--- a/Resource/template/default/Event/ShoppingConfirm/use_point_button.twig
+++ b/Resource/template/default/Event/ShoppingConfirm/use_point_button.twig
@@ -4,7 +4,18 @@
         <p id="point_box__info" class="text-left">
             現在の保有ポイントは「<strong class="text-primary">{{ (point.current) >= 0 ? (point.current)|number_format  : 0 }} pt</strong>」です。<br/>
             ポイントは商品購入時に1pt＝<strong class="text-primary">{{ point.rate|price }}</strong>として利用することができます。
-            <a id="confirm_box__use_point_edit_button" href="{{ url('point_use') }}" class="btn btn-default btn-sm">ポイントを利用する</a>
+            <a id="confirm_box__use_point_edit_button" href="{{ url('step_use_point', {id: Order.id}) }}" class="btn btn-default btn-sm">ポイントを利用する</a>
         </p>
     </div>
 </div>
+<script>
+$(function() {
+
+    $('#confirm_box__use_point_edit_button').click(function() {
+        $('#shopping-form').attr('action', $(this).attr('href')).submit();
+        $('#shopping-form').attr('action', '{{ url('shopping_confirm') }}');
+        return false;
+    });
+
+});
+</script>

--- a/ServiceProvider/PointServiceProvider.php
+++ b/ServiceProvider/PointServiceProvider.php
@@ -49,6 +49,17 @@ class PointServiceProvider implements ServiceProviderInterface
         /**
          * ルーティング登録
          * フロント画面 > 商品購入確認画面
+         * ポイント入力画面へ遷移する前に注文設定を一時的に保存
+         * お届け先情報変更処理を参考に実装
+         */
+        $app->match(
+            '/shopping/step_use_point/{id}',
+            'Plugin\Point\Controller\FrontPointController::stepUsePoint'
+        )->assert('id', '\d+')->bind('step_use_point');
+
+        /**
+         * ルーティング登録
+         * フロント画面 > 商品購入確認画面
          */
         $app->match(
             '/shopping/use_point',


### PR DESCRIPTION
購入確認画面でポイント使用ボタンをクリックすると使用ポイント入力フォームに遷移しますが、購入確認画面に戻ってきたときに設定されていた配送日時が未選択状態になってしまうのを修正しました。
お届け先変更処理を参考にしました。