### PR TITLE
3.0.18をテストケースに追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     # ec-cube 3.0.16
     - ECCUBE_VERSION=3.0.16 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.16 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    # ec-cube 3.0.18
+    # ec-cube 3.0.x
     - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 install:
@@ -65,8 +65,9 @@ before_script:
   - git clone https://github.com/EC-CUBE/ec-cube.git
   - cd ec-cube
   # checkout version
-  - sh -c "if [ ! '${ECCUBE_VERSION}' = '3.0' ]; then  git checkout -b ${ECCUBE_VERSION} refs/tags/${ECCUBE_VERSION}; fi"
   - sh -c "if [ '${ECCUBE_VERSION}' = '3.0' ]; then  git checkout -b ${ECCUBE_VERSION} origin/${ECCUBE_VERSION}; fi"
+  - sh -c "if [ '${ECCUBE_VERSION}' = '3.1' ]; then  git checkout -b ${ECCUBE_VERSION} origin/${ECCUBE_VERSION}; fi"
+  - sh -c "if [ ! '${ECCUBE_VERSION}' = '3.1' -a ! '${ECCUBE_VERSION}' = '3.0' ]; then  git checkout -b ${ECCUBE_VERSION} refs/tags/${ECCUBE_VERSION}; fi"
   # update composer
   - composer selfupdate
   - composer install --dev --no-interaction -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 
 sudo: required
 
+services:
+  - docker
+
 cache:
   directories:
     - $HOME/.composer/cache
@@ -13,8 +16,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-
-dist: precise
 
 env:
   # plugin code
@@ -31,9 +32,12 @@ env:
     # ec-cube 3.0.x
     - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+before_install:
+  - docker pull schickling/mailcatcher
+  - docker run -d -p 1080:1080 -p 1025:1025 --name mailcatcher schickling/mailcatcher
+
 install:
   - gem install mime-types -v 2.99.1
-  - gem install mailcatcher
 
 matrix:
   fast_finish: true
@@ -77,7 +81,6 @@ before_script:
   - php app/console plugin:develop install --path=${HOME}/${PLUGIN_CODE}.tar.gz
   # enable plugin
   - php app/console plugin:develop enable --code=${PLUGIN_CODE}
-  - mailcatcher
 
 script:
   # exec phpunit on ec-cube

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ env:
     # ec-cube 3.0.16
     - ECCUBE_VERSION=3.0.16 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.16 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-
+    # ec-cube 3.0.18
+    - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 install:
   - gem install mime-types -v 2.99.1
   - gem install mailcatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,17 @@ env:
   global:
     PLUGIN_CODE=Point
   matrix:
-    # ec-cube 3.0
-    - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres COVERAGE=1
-    # ec-cube 3.0.16
-    - ECCUBE_VERSION=3.0.16 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.16 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    # ec-cube 3.0.x
+    # ec-cube 3.1
+    - ECCUBE_VERSION=3.1 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres COVERAGE=1
+    # ec-cube 3.0.17
+    - ECCUBE_VERSION=3.0.17 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.0.17 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    # ec-cube 3.0.18
+    - ECCUBE_VERSION=3.0.18 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.0.18 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+  # ec-cube 3.0.x
     - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ php:
   - 7.0
   - 7.1
 
+dist: trusty
+
 env:
   # plugin code
   global:
@@ -25,7 +27,6 @@ env:
     # ec-cube 3.1
     - ECCUBE_VERSION=3.1 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    - ECCUBE_VERSION=3.1 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres COVERAGE=1
     # ec-cube 3.0.17
     - ECCUBE_VERSION=3.0.17 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.17 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
@@ -35,9 +36,10 @@ env:
   # ec-cube 3.0.x
     - ECCUBE_VERSION=3.0 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    - ECCUBE_VERSION=3.0 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres COVERAGE=1
 before_install:
-  - docker pull schickling/mailcatcher
-  - docker run -d -p 1080:1080 -p 1025:1025 --name mailcatcher schickling/mailcatcher
+  - if [[ $DIST = 'trusty' ]]; then docker pull schickling/mailcatcher ; fi
+  - if [[ $DIST = 'trusty' ]]; then docker run -d -p 1080:1080 -p 1025:1025 --name mailcatcher schickling/mailcatcher ; fi
 
 install:
   - gem install mime-types -v 2.99.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
     DBPASS: "Password12!"
     DBUSER: "root"
     BASE_DIR: "C:/projects/ec-cube"
-    ECCUBE_VERSION: "master"
+    ECCUBE_VERSION: "3.0"
     PLUGIN_CODE: "Point"
   matrix:
   - db: mysql


### PR DESCRIPTION
3.0.18をTravis-CIのテストケースに追加しました。

### php5.4でのmailcatcherを利用したテストについて
php5.4でのテストをするためには `dist: precise` を利用しないといけないのですが、このdistributionではdockerコマンドが利用できないためmailcatcherを導入できません。
php5.4だけでmailcatcherを利用したテストケースがNGになるリスクは低いと考え、php5.4のときはmailcatcherを利用したテストケースはSkipしています。